### PR TITLE
Normalize to IPv6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,19 @@ build-agent:
 .PHONY: build
 build: build-probes build-agent
 
+.PHONY: test-agent
+test-agent:
+	$(RUSTUP) cargo test
+
+.PHONY: test-probes
+test-probes:
+	cd probes && $(RUSTUP) cargo test
+
+.PHONY: test
+test: test-probes test-agent
+
 .PHONY: release
-release: clean build
+release: clean test build
 
 .PHONY: run
 run:

--- a/probes/src/common/mod.rs
+++ b/probes/src/common/mod.rs
@@ -1,31 +1,132 @@
 use core::fmt;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct IPv6Address {
+    pub a: u16,
+    pub b: u16,
+    pub c: u16,
+    pub d: u16,
+    pub e: u16,
+    pub f: u16,
+    pub g: u16,
+    pub h: u16,
+}
+
+impl IPv6Address {
+    /// Converts a given IPv4 address represented as a u32 into an IPv6Address.
+    pub fn from_v4u32(address: u32) -> Self {
+        let octets: [u8; 4] = address.to_be_bytes();
+        IPv6Address { 
+            a: 0, 
+            b: 0, 
+            c: 0, 
+            d: 0, 
+            e: 0, 
+            f: 0xffff, 
+            g: ((octets[0] as u16) << 8) | octets[1] as u16, 
+            h: ((octets[2] as u16) << 8) | octets[3] as u16,
+        }        
+    }
+
+    /// Returns true if the IPv6Address can be represnted as an IPv4
+    pub fn is_v4(&self) -> bool {
+        self.a == 0 && 
+        self.b == 0 &&
+        self.c == 0 &&
+        self.d == 0 &&
+        self.e == 0 &&
+        self.f == 0xffff
+    }
+}
+
+impl fmt::Display for IPv6Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_v4() {
+            let upper = self.g.to_be_bytes();
+            let lower = self.h.to_be_bytes();
+            write!(f, "{}.{}.{}.{}", upper[0], upper[1], lower[0], lower[1])
+        } else {
+            write!(f, "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
+                self.a, self.b, self.c, self.d,
+                self.e, self.f, self.g, self.h)
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
-pub struct SocketAddr {
-    pub addr: u32,
+pub struct SocketAddress {
+    pub address: IPv6Address,
     pub port: u16,
     _padding: u16,
 }
 
-impl SocketAddr {
-    pub fn new(addr: u32, port: u16) -> Self {
-        SocketAddr {
-            addr,
+impl SocketAddress {
+    pub fn new(address: IPv6Address, port: u16) -> Self {
+        SocketAddress {
+            address,
             port,
             _padding: 0,
         }
     }
 }
 
-impl fmt::Display for SocketAddr {
+impl fmt::Display for SocketAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let octets: [u8; 4] = self.addr.to_ne_bytes();
+        if self.address.is_v4() {
+            self.address.fmt(f)?;
+            write!(f, ":{}", self.port)
+        } else {
+            write!(f, "[")?;
+            self.address.fmt(f)?;
+            write!(f, "]:{}", self.port)
+        }
+    }
+}
 
-        write!(
-            f,
-            "{:^3}.{:^3}.{:^3}.{:^3}:{:<5}",
-            octets[3], octets[2], octets[1], octets[0], self.port
-        )
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv6address_from_v4u32() {
+        // 192.168.1.1
+        let v4 = 3232235777;
+
+        let address = IPv6Address::from_v4u32(v4);
+        let expected = IPv6Address {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            f: 0xffff,
+            g: 0xc0a8,
+            h: 0x0101,
+        };
+
+        assert_eq!(expected, address);
+    }
+
+    #[test]
+    fn ipv6address_is_ipv4() {
+        let address = IPv6Address::from_v4u32(0);
+        assert!(address.is_v4());
+    }
+
+    #[test]
+    fn ipv6address_is_ipv4_false() {
+        let address = IPv6Address {
+            a: 0x2001,
+            b: 0x0db8,
+            c: 0xac10,
+            d: 0xfe01,
+            e: 0,
+            f: 0,
+            g: 0,
+            h: 0,
+        };
+        assert!(!address.is_v4());
     }
 }

--- a/probes/src/dns/main.rs
+++ b/probes/src/dns/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use redbpf_probes::xdp::prelude::*;
-use probes::{dns::DNSEvent, common::SocketAddr};
+use probes::{dns::DNSEvent, common::IPv6Address, common::SocketAddress};
 
 program!(0xFFFFFFFE, "GPL");
 
@@ -21,8 +21,8 @@ pub fn filter_dns(ctx: XdpContext) -> XdpResult {
     }
 
     let event = DNSEvent {
-        src: SocketAddr::new(ip.saddr, transport.source()),
-        dest: SocketAddr::new(ip.daddr, transport.dest()),
+        src: SocketAddress::new(IPv6Address::from_v4u32(ip.saddr), transport.source()),
+        dest: SocketAddress::new(IPv6Address::from_v4u32(ip.daddr), transport.dest()),
     };
     unsafe {
         events.insert(

--- a/probes/src/dns/mod.rs
+++ b/probes/src/dns/mod.rs
@@ -1,8 +1,8 @@
-use crate::common::SocketAddr;
+use crate::common::SocketAddress;
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct DNSEvent {
-    pub src: SocketAddr,
-    pub dest: SocketAddr,
+    pub src: SocketAddress,
+    pub dest: SocketAddress,
 }

--- a/probes/src/network/mod.rs
+++ b/probes/src/network/mod.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use super::common::SocketAddr;
+use super::common::SocketAddress;
 
 #[derive(Copy, Clone)]
 pub enum SocketCloseState {
@@ -30,8 +30,8 @@ impl fmt::Display for SocketCloseState {
 #[repr(C)]
 #[derive(Debug)]
 pub struct TCPSummary {
-    pub src: SocketAddr,
-    pub dst: SocketAddr,
+    pub src: SocketAddress,
+    pub dst: SocketAddress,
     pub duration: u64,
     pub close_state: u64,
 }


### PR DESCRIPTION
Normalizes all address to IPv6, updates fmt::Display impls to pretty-print based on whether the IP is a v4 or v6. Adds unit tests for conversion logic.